### PR TITLE
Implement VOOG intro overlay targets

### DIFF
--- a/components/edicy-tools-variables.tpl
+++ b/components/edicy-tools-variables.tpl
@@ -225,4 +225,10 @@
       }
     ]
   {% endcapture %}
+
+  {% comment %}VOOG intro popover targets. Add them where applicable popovers should appear.{% endcomment %}
+  {% capture edy_intro_add_page %}{% if editmode %}data-edy-intro-popover="edy-add-page"{% endif %}{% endcapture %}
+  {% capture edy_intro_add_lang %}{% if editmode %}data-edy-intro-popover="edy-add-lang"{% endif %}{% endcapture %}
+  {% capture edy_intro_edit_text %}{% if editmode %}data-edy-intro-popover="edy-edit-text"{% endif %}{% endcapture %}
+
 {% endcapture %}{% comment %} END edicy-tools-variables {% endcomment %}

--- a/components/menu-lang.tpl
+++ b/components/menu-lang.tpl
@@ -2,5 +2,5 @@
   {% for language in site.languages %}
     <li class="menu-item"><a class="menu-link{% if language.selected? %} active{% endif %}" href="{{ language.url }}">{{ language.title }}</a></li>
   {% endfor %}
-  {% if editmode %}<li class="edit-btn">{% languageadd %}</li>{% endif %}
+  {% if editmode %}<li class="edit-btn" {{ edy_intro_add_lang }}>{% languageadd %}</li>{% endif %}
 </ul>

--- a/components/menu-level-1.tpl
+++ b/components/menu-level-1.tpl
@@ -16,6 +16,6 @@
       <li class="edit-btn">{% menubtn site.hidden_menuitems %}</li>
     {% endif %}
 
-    <li class="edit-btn">{% menuadd %}</li>
+    <li class="edit-btn" {{ edy_intro_add_page }}>{% menuadd %}</li>
   {% endif %}
 </ul>

--- a/layouts/blog_article.tpl
+++ b/layouts/blog_article.tpl
@@ -33,8 +33,8 @@
             </header>
 
             <div class="post-content" data-search-indexing-allowed="true">
-              <div class="post-excerpt content-formatted">{% editable article.excerpt %}</div>
-              <div class="post-body content-formatted" {{ edy_intro_edit_text }}>{% editable article.body %}</div>
+              <div class="post-excerpt content-formatted" {{ edy_intro_edit_text }}>{% editable article.excerpt %}</div>
+              <div class="post-body content-formatted">{% editable article.body %}</div>
             </div>
 
             {% include "tags-post" %}

--- a/layouts/blog_article.tpl
+++ b/layouts/blog_article.tpl
@@ -34,7 +34,7 @@
 
             <div class="post-content" data-search-indexing-allowed="true">
               <div class="post-excerpt content-formatted">{% editable article.excerpt %}</div>
-              <div class="post-body content-formatted">{% editable article.body %}</div>
+              <div class="post-body content-formatted" {{ edy_intro_edit_text }}>{% editable article.body %}</div>
             </div>
 
             {% include "tags-post" %}

--- a/layouts/common_page.tpl
+++ b/layouts/common_page.tpl
@@ -16,7 +16,7 @@
     <main class="content js-background-type {{ body_bg_type }}" role="main">
       <div class="wrap">
         {% include "menu-level-2" %}
-        <section class="wrap-inner content-formatted" data-search-indexing-allowed="true">{% content %}</section>
+        <section class="wrap-inner content-formatted" data-search-indexing-allowed="true" {{ edy_intro_edit_text }}>{% content %}</section>
       </div>
     </main>
 

--- a/layouts/front_page.tpl
+++ b/layouts/front_page.tpl
@@ -52,7 +52,7 @@
           {% endfor %}
         </section>
 
-        <section class="content-formatted" data-search-indexing-allowed="true">{% content %}</section>
+        <section class="content-formatted" data-search-indexing-allowed="true" {{ edy_intro_edit_text }}>{% content %}</section>
       </div>
     </main>
 


### PR DESCRIPTION
Current targetable areas are:
```
data-edy-intro-popover="edy-add-page"
data-edy-intro-popover="edy-add-lang"
data-edy-intro-popover="edy-edit-text"
```