### PR TITLE
Display Voog reference only on front page of site

### DIFF
--- a/components/footer.tpl
+++ b/components/footer.tpl
@@ -7,9 +7,16 @@
         {%- assign footer_content_title_tooltip = "content_tooltip_all_pages_same_language" | lce -%}
         {% xcontent name="footer" title=footer_content_title title_tooltip=footer_content_title_tooltip %}
       </div>
-      <div class="footer-right">
-        <div class="voog-reference">{% loginblock %}{{ "footer_login_link" | lc }}{% endloginblock %}</div>
-      </div>
+
+      {% if site.branding.enabled and page.path == blank -%}
+        <div class="footer-right">
+          <div class="voog-reference">
+            {% loginblock %}
+              {{ "footer_login_link" | lc }}
+            {% endloginblock %}
+          </div>
+        </div>
+      {% endif -%}
     </div>
   </div>
 </footer>


### PR DESCRIPTION
- Voog reference is displayed only on front page of site
- Reference respects `site.branding.enabled` value.

Closes #171 